### PR TITLE
Attempt 1 at fixing black models with Blend shader

### DIFF
--- a/src/main/resources/ShaderLib/PBRLighting.glsllib
+++ b/src/main/resources/ShaderLib/PBRLighting.glsllib
@@ -22,15 +22,9 @@ uniform vec4 g_AmbientLightColor;
     uniform mat4 g_LightProbeData3;
 #endif
 
-// Specular-AA
-#ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
-    uniform float m_SpecularAASigma;
-#endif
-#ifdef SPECULAR_AA_THRESHOLD
-    uniform float m_SpecularAAKappa;
-#endif
 
-vec3 calculatePBRLighting(in vec4 albedo, in float Metallic, in float Roughness, in vec4 specularColor, in float glossiness, in vec3 lightMapColor, in vec3 ao, in float indoorSunLightExposure, in vec3 normal, in vec3 norm, in vec3 viewDir){
+vec3 calculatePBRLighting(){
+//vec3 calculatePBRLighting(in vec4 albedo, in float Metallic, in float Roughness, in vec4 specularColor, in float glossiness, in vec3 lightMapColor, in vec3 ao, in float indoorSunLightExposure, in vec3 normal, in vec3 norm, in vec3 viewDir){
     vec3 finalLightingValue;
     
     #ifdef SPECGLOSSPIPELINE

--- a/src/main/resources/ShaderLib/PBRLightingParamsReader.glsllib
+++ b/src/main/resources/ShaderLib/PBRLightingParamsReader.glsllib
@@ -56,6 +56,14 @@ uniform float m_Metallic;
 #ifdef AO_STRENGTH
     uniform float m_AoStrength;
 #endif
+
+// Specular-AA
+#ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
+    uniform float m_SpecularAASigma;
+#endif
+#ifdef SPECULAR_AA_THRESHOLD
+    uniform float m_SpecularAAKappa;
+#endif
   
 #if defined(NORMALMAP) || defined(PARALLAXMAP)
     uniform sampler2D m_NormalMap;       
@@ -71,7 +79,8 @@ uniform float m_Metallic;
     uniform float m_StaticSunIntensity;
 #endif
 
-void readMatParamsAndTextures(in mat3 tbnMat, in vec3 vViewDir, inout vec4 albedo, inout float Metallic, inout float Roughness, inout vec4 SpecularColor, inout float glossiness, inout vec3 lightMapColor, inout vec3 ao, inout vec3 normal, inout vec4 emissive, inout float alpha){
+//void readMatParamsAndTextures(in mat3 tbnMat, in vec3 vViewDir, inout vec4 albedo, inout float Metallic, inout float Roughness, inout vec4 SpecularColor, inout float glossiness, inout vec3 lightMapColor, inout vec3 ao, inout vec3 normal, inout vec4 emissive, inout float alpha){
+void readMatParamsAndTextures(){
     #if (defined(PARALLAXMAP) || (defined(NORMALMAP_PARALLAX) && defined(NORMALMAP)))
         #ifdef STEEP_PARALLAX
             #ifdef NORMALMAP_PARALLAX

--- a/src/main/resources/Shaders/PBRCharacters.frag
+++ b/src/main/resources/Shaders/PBRCharacters.frag
@@ -19,8 +19,6 @@ varying vec4 wTangent;
     uniform int m_DebugValuesMode;
 #endif
 
-#import "ShaderLib/PBRLightingParamsReader.glsllib"
-#import "ShaderLib/PBRLighting.glsllib"
 // It is important that these 2 glsllibs are referenced AFTER the other variables above have been declared. 
 // The above variables are declared here (rather than in a glsllib) to reduce redundancy, since these variables are likely to be used by more than one glsllib.
 // Only lighting variables are declared in PBRLighting.glsllib, and only basic PBR material params are declared in PBRLightingParamsReader.glsllib.
@@ -48,26 +46,39 @@ float Roughness = 0.0;
 vec4 specularColor;
 float glossiness = 0.0;
 
+vec3 norm;
+vec3 normal;
+vec3 viewDir;
+
+mat3 tbnMat;
+vec3 vViewDir;
+
+#import "ShaderLib/PBRLightingParamsReader.glsllib"
+#import "ShaderLib/PBRLighting.glsllib"
+
 void main(){
     
-    vec3 norm = normalize(wNormal);
-    vec3 normal = norm.xyz;
-    vec3 viewDir = normalize(g_CameraPosition - wPosition);
+    norm = normalize(wNormal);
+    normal = norm.xyz;
+    viewDir = normalize(g_CameraPosition - wPosition);
 
     // Note: These are intentionally not surrounded by ifDefs relating to normal and parallax maps being defined, because
     // other .glsllibs may require normal or parallax mapping even if the base model does not have those maps
     vec3 tan = normalize(wTangent.xyz);
-    mat3 tbnMat = mat3(tan, wTangent.w * cross( (norm), (tan)), norm); 
-    vec3 vViewDir =  viewDir * tbnMat;                                 
+    tbnMat = mat3(tan, wTangent.w * cross( (norm), (tan)), norm); 
+    vViewDir =  viewDir * tbnMat;                                 
 
     //base PBR params and tex reads:
-    readMatParamsAndTextures(tbnMat, vViewDir, albedo, Metallic, Roughness, specularColor, glossiness, lightMapColor, ao, normal, emissive, alpha);
+     readMatParamsAndTextures();
+  //  readMatParamsAndTextures(tbnMat, vViewDir, albedo, Metallic, Roughness, specularColor, glossiness, lightMapColor, ao, normal, emissive, alpha);
     
     
     applyAllBlendEffects(albedo, normal, Roughness, Metallic, ao, emissive, glossiness, newTexCoord, wPosition, norm, tbnMat);
     
     // Lighting calculation:    
-    vec3 finalLightingValue = calculatePBRLighting(albedo, Metallic, Roughness, specularColor, glossiness, lightMapColor, ao, indoorSunLightExposure, normal, norm, viewDir);
+  //  vec3 finalLightingValue = calculatePBRLighting(albedo, Metallic, Roughness, specularColor, glossiness, lightMapColor, ao, indoorSunLightExposure, normal, norm, viewDir);
+    vec3 finalLightingValue = calculatePBRLighting();
+    
     gl_FragColor.rgb += finalLightingValue;
 
     //apply final emissive value after lighting


### PR DESCRIPTION
I made a quick update to the shaders that changes some simple things that may or may not have been part of the issue

I'm not confident this will solve the issue, but it was the first simple thing I can quickly try without asking you for more information. So let me know if it does fix it it by chance.

And if not, then one more thing to try would be to remove the base normal map from the Erika model, and then left me know if that gets the black-rendering to go away. 

Also, if the issue still persists after this PR, it could be useful to set the "DebugValuesMode" MatParam to debug each channel individually, and then take a screenshot so I can see what it looks like showing each individual channel.

That way I can know if it is related to the final lighting calculation, or if it is an issue with a single broken ao/normal channel, since bad normals or an AO value of 0.0 will often cause fully black rendering. But it could also be any number of variables that get sent into the final lighting equation that are not having the proper value set.