### PR TITLE
Fix issue with original Emissive Color

### DIFF
--- a/src/main/resources/ShaderLib/PBRLightingParamsReader.glsllib
+++ b/src/main/resources/ShaderLib/PBRLightingParamsReader.glsllib
@@ -193,10 +193,12 @@ void readMatParamsAndTextures(in mat3 tbnMat, in vec3 vViewDir, inout vec4 albed
     
     #if defined(EMISSIVE) || defined (EMISSIVEMAP)
         #ifdef EMISSIVEMAP
-            emissive = texture2D(m_EmissiveMap, newTexCoord);
+            emissive = texture2D(m_EmissiveMap, newTexCoord);    
             #ifdef EMISSIVE
-            emissive *= m_Emissive;
-            #endif
+                emissive *= m_Emissive;
+            #endif  
+        #else
+            emissive = m_Emissive; 
         #endif
         emissive = emissive * pow(emissive.a, m_EmissivePower) * m_EmissiveIntensity;
     #endif


### PR DESCRIPTION
Accidentally forgot to read original emissive color. Emissive from an emissiveMap or adiditional blend layers worked, but I had just forgotten to read the original Emissive color value. 